### PR TITLE
Failing test for constructing internal classes

### DIFF
--- a/StructureMap.Dnx.sln
+++ b/StructureMap.Dnx.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1AAD948C-6BBE-4334-BFF2-AA5F16F63845}"
 EndProject
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8037CE7A-0
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "StructureMap.Dnx.Tests", "test\StructureMap.Dnx.Tests\StructureMap.Dnx.Tests.xproj", "{2B3D64C5-CA4D-41E5-AF3A-BA90AB80EB60}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "StructureMap.Dnx.Tests.Internal", "test\StructureMap.Dnx.Tests.Internal\StructureMap.Dnx.Tests.Internal.xproj", "{D899CE66-EDCB-4062-B0B3-018F575535CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,10 @@ Global
 		{2B3D64C5-CA4D-41E5-AF3A-BA90AB80EB60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B3D64C5-CA4D-41E5-AF3A-BA90AB80EB60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B3D64C5-CA4D-41E5-AF3A-BA90AB80EB60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D899CE66-EDCB-4062-B0B3-018F575535CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D899CE66-EDCB-4062-B0B3-018F575535CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D899CE66-EDCB-4062-B0B3-018F575535CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D899CE66-EDCB-4062-B0B3-018F575535CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -38,5 +44,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{D09D9E47-E9B7-4446-90AE-48AE3358C880} = {1AAD948C-6BBE-4334-BFF2-AA5F16F63845}
 		{2B3D64C5-CA4D-41E5-AF3A-BA90AB80EB60} = {8037CE7A-020C-48D2-9C7E-BBEB669E19D7}
+		{D899CE66-EDCB-4062-B0B3-018F575535CF} = {8037CE7A-020C-48D2-9C7E-BBEB669E19D7}
 	EndGlobalSection
 EndGlobal

--- a/test/StructureMap.Dnx.Tests.Internal/IInternalService.cs
+++ b/test/StructureMap.Dnx.Tests.Internal/IInternalService.cs
@@ -1,0 +1,6 @@
+﻿namespace StructureMap.Dnx.Tests.Internal
+{
+    public interface IInternalService
+    {
+    }
+}

--- a/test/StructureMap.Dnx.Tests.Internal/InternalService.cs
+++ b/test/StructureMap.Dnx.Tests.Internal/InternalService.cs
@@ -1,0 +1,6 @@
+﻿namespace StructureMap.Dnx.Tests.Internal
+{
+    internal class InternalService : IInternalService
+    {
+    }
+}

--- a/test/StructureMap.Dnx.Tests.Internal/ServicesFactory.cs
+++ b/test/StructureMap.Dnx.Tests.Internal/ServicesFactory.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace StructureMap.Dnx.Tests.Internal
+{
+    public static class ServicesFactory
+    {
+        public static IServiceCollection GetServiceCollection()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddTransient<IInternalService, InternalService>();
+
+            return serviceCollection;
+        }
+    }
+}

--- a/test/StructureMap.Dnx.Tests.Internal/StructureMap.Dnx.Tests.Internal.xproj
+++ b/test/StructureMap.Dnx.Tests.Internal/StructureMap.Dnx.Tests.Internal.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d899ce66-edcb-4062-b0b3-018f575535cf</ProjectGuid>
+    <RootNamespace>StructureMap.Dnx.Tests.Internal</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/StructureMap.Dnx.Tests.Internal/project.json
+++ b/test/StructureMap.Dnx.Tests.Internal/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4.0-*",
 
   "commands": {
@@ -7,7 +7,8 @@
 
   "dependencies": {
     "StructureMap.Dnx": { "target": "project" },
-    "StructureMap.Dnx.Tests.Internal": { "target": "project" },
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc1-final",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc1-final",
     "xunit": "2.1.0-rc1-build3168",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/StructureMap.Dnx.Tests/InternalServiceTest.cs
+++ b/test/StructureMap.Dnx.Tests/InternalServiceTest.cs
@@ -1,0 +1,23 @@
+﻿using StructureMap.Dnx.Tests.Internal;
+using System;
+using Xunit;
+
+namespace StructureMap.Dnx.Tests
+{
+    public class InternalServiceTest
+    {
+        [Fact]
+        public void CanGetInternalService()
+        {
+            var container = new Container();
+
+            container.Populate(ServicesFactory.GetServiceCollection());
+
+            var provider = container.GetInstance<IServiceProvider>();
+
+            var internalService = provider.GetService(typeof(IInternalService));
+
+            Assert.NotNull(internalService);
+        }
+    }
+}


### PR DESCRIPTION
When an internal class is registered in `IServiceCollection` before passing to the `Populate` extension method, then this class cannot be constructed by `StructureMapServiceProvider`. This pull request contains a failing test.